### PR TITLE
Fix external share breadcrumb

### DIFF
--- a/css/files_sharing.css
+++ b/css/files_sharing.css
@@ -171,6 +171,9 @@
 
 		.breadcrumb {
 			filter: var(--ion-icon-filter-blue-b8);
+			.icon-more.menutoggle {
+				background-size: 17px;
+			}
 
 			.crumbhome a {
 				padding: 12px 12px 12px 35px;

--- a/css/files_sharing.css
+++ b/css/files_sharing.css
@@ -170,7 +170,6 @@
 		}
 
 		.breadcrumb {
-			filter: var(--ion-icon-filter-blue-b8);
 			.icon-more.menutoggle {
 				background-size: 17px;
 			}


### PR DESCRIPTION
the icon ">" in beadcrumb stays default and not "---ionos-blue-8". I couldn't find reasonable way to change the color of background image without applyinf filters that make the of more-button popover menu unreadable.

```		
li.crumb {
+				&:not(:has(div.popovermenu) ) {
+					filter: var(--ion-icon-filter-blue-b8);
+				}
+
 				height: 51px; a {
 					color: var(--ion-color-secondary);
 					opacity: 1;
 				}
}
 
or:

 li.crumb {
+				filter: var(--ion-icon-filter-blue-b8);
 				height: 51px; a {
 					color: var(--ion-color-secondary);
 					opacity: 1;
 				}
+
+				div.popovermenu.menu-center.menu {
+					filter: none;
+				}
}
