### PR TITLE
tkl/fix/chevrone size

### DIFF
--- a/css/files.css
+++ b/css/files.css
@@ -105,6 +105,8 @@
 
 				.vue-crumb__separator {
 					color: var(--ion-breadcrumb-text);
+					width: 16px;
+					height: 16px;
 				}
 			}
 		}

--- a/css/navigation.css
+++ b/css/navigation.css
@@ -78,8 +78,8 @@
 			margin: 6px;
 			background-color: transparent;
 			span[role=img]>svg {
-				height: 24px;
-				width: 24px;
+				height: 16px;
+				width: 16px;
 				color: var(--ion-button-sidebar-text);
 			}
 			&:hover {


### PR DESCRIPTION
just realized, that after update to V30.0.5. the chevron icon in side bar navigaion and breadcrumb looks huge:
![chevron-size](https://github.com/user-attachments/assets/d6841e62-4817-4d9c-9c9a-12b55dbee376)

According Figma it schould be 16px x 16px  
