### PR TITLE
style(navigation): hide pending shares

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -54,6 +54,11 @@
 			}
 		}
 
+
+		li[data-cy-files-navigation-item="pendingshares"] {
+			display: none;
+		}
+
 		/* Navigation Toggle Button */
 		div.app-navigation-toggle-wrapper button.app-navigation-toggle.button-vue--icon-only {
 			margin: 18px 0;


### PR DESCRIPTION
Apparently there is no config for pending shares of federated shares, so opted for this solution to reduce potential merge conflicts in upcoming updates.