### PR TITLE
styles(files_sharing): fix fileactions background

### DIFF
--- a/css/files_sharing.css
+++ b/css/files_sharing.css
@@ -374,6 +374,9 @@
 				td.selection label {
 					display: grid;
 				}
+				&:not(:hover):not(.selected) .fileactions {
+					background-color: var(--ion-color-main-background);
+				}
 			}
 
 			.thumbnail-wrapper {


### PR DESCRIPTION
This is a fix for [HDNEXT-1135](https://hosting-jira.1and1.org/browse/HDNEXT-1135): Grid view Thumbnails of link share not displayed correctly with narrow viewport, see attached screencast in the ticket.