### PR TITLE
chore(theme): add primary text color variable for improved contrast

### DIFF
--- a/lib/Themes/OverrideDefaultTheme.php
+++ b/lib/Themes/OverrideDefaultTheme.php
@@ -150,6 +150,7 @@ class OverrideDefaultTheme extends DefaultTheme implements ITheme {
 			'--color-main-background-blur' => 'rgba(var(--color-main-background-rgb), .8)',
 			'--color-primary' => $colorPrimary,
 			'--color-primary-element' => $colorPrimary,
+			'--color-primary-text' => 'var(--color-text-maxcontrast)',
 
 			// to use like this: background-image: linear-gradient(0, var('--gradient-main-background));
 			'--gradient-main-background' => 'var(--color-main-background) 0%, var(--color-main-background-translucent) 85%, transparent 100%',


### PR DESCRIPTION
Fix for limit download text in header in apps-external/files_downloadlimit.

This is an exhaustive alternative for https://github.com/nextcloud/files_downloadlimit/pull/487, which still requires a css fix.