### PR TITLE
chore: bump max-version to 33 (HDNEXT-1596)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 	<category>customization</category>
 	<bugs>https://github.com/IONOS-Productivity/nc-theming/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="30" max-version="31"/>
+		<nextcloud min-version="30" max-version="33"/>
 	</dependencies>
 	<!--
 	- no navigations configured

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		"php": "^8.1"
 	},
 	"require-dev": {
-		"nextcloud/ocp": "^v31.0.6",
+		"nextcloud/ocp": "^v33.0.0",
 		"roave/security-advisories": "dev-latest"
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c940e8843bcc53a334d4e137c778079",
+    "content-hash": "cc5f30650fb9615a70efc5002e73d72b",
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -67,20 +67,20 @@
     "packages-dev": [
         {
             "name": "nextcloud/ocp",
-            "version": "v31.0.6",
+            "version": "v33.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "bec55048b46eadbd2c564f2b26c9486a43f958c2"
+                "reference": "f5a898fb7795fa28a135f528105b8628df6d97f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/bec55048b46eadbd2c564f2b26c9486a43f958c2",
-                "reference": "bec55048b46eadbd2c564f2b26c9486a43f958c2",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f5a898fb7795fa28a135f528105b8628df6d97f5",
+                "reference": "f5a898fb7795fa28a135f528105b8628df6d97f5",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1 || ~8.2 || ~8.3 || ~8.4",
+                "php": "~8.1 || ~8.2 || ~8.3 || ~8.4 || ~8.5",
                 "psr/clock": "^1.0",
                 "psr/container": "^2.0.2",
                 "psr/event-dispatcher": "^1.0",
@@ -89,7 +89,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-stable31": "31.0.0-dev"
+                    "dev-stable33": "33.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -109,9 +109,9 @@
             "description": "Composer package containing Nextcloud's public OCP API and the unstable NCU API",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/v31.0.6"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/v33.0.2"
             },
-            "time": "2025-05-28T00:52:27+00:00"
+            "time": "2026-03-27T01:17:36+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
## Summary

- Bump `max-version` to `33` in `appinfo/info.xml`
- Update `nextcloud/ocp` to `^v33.0.0` in `composer.json` (resolves to v33.0.2)

## Audit

- `OC_Helper::` usages: none found ✅
- `OC_Util::$scripts/$styles` in tests: none found ✅
- `OC_Template` / legacy classes: none found ✅
- `OCA.Files.Sidebar` / `OC.AppConfig` (JS): none found ✅
- `app.php` in appinfo: not present ✅
- `IJob::execute()`: none found ✅
- `IQueryBuilder::execute()`: none found ✅

Jira: [HDNEXT-1596](https://hosting-jira.1and1.org/browse/HDNEXT-1596)