### PR TITLE
style(buttons): remove FA-specific chevron icon size workaround

### DIFF
--- a/css/buttons.css
+++ b/css/buttons.css
@@ -321,12 +321,6 @@
 		align-items: center;
 		gap: 8px;
 	}
-
-	/* drop down chevron-up and down icon */
-	.vs__open-indicator-button svg{
-		height: 24px;
-		width: 24px;
-	}
 }
 
 #body-user, #body-public {

--- a/css/files.css
+++ b/css/files.css
@@ -109,8 +109,6 @@
 
 				.vue-crumb__separator {
 					color: var(--ion-breadcrumb-text);
-					width: 16px;
-					height: 16px;
 				}
 			}
 		}

--- a/css/navigation.css
+++ b/css/navigation.css
@@ -77,8 +77,8 @@
 			margin: 6px;
 			background-color: transparent;
 			span[role=img]>svg {
-				height: 16px;
-				width: 16px;
+				height: 24px;
+				width: 24px;
 				color: var(--ion-button-sidebar-text);
 			}
 			&:hover {

--- a/css/navigation.css
+++ b/css/navigation.css
@@ -12,8 +12,6 @@
 		.app-navigation-entry {
 			span[role=img]>svg {
 				color: var(--ion-button-sidebar-text);
-				height: 16px;
-				width: auto;
 			}
 			.app-navigation-entry__name {
 				font-weight: 600;

--- a/css/navigation.css
+++ b/css/navigation.css
@@ -75,7 +75,6 @@
 			margin: 6px;
 			background-color: transparent;
 			span[role=img]>svg {
-				height: 16px;
 				color: var(--ion-button-sidebar-text);
 			}
 			&:hover {

--- a/css/navigation.css
+++ b/css/navigation.css
@@ -77,8 +77,7 @@
 			margin: 6px;
 			background-color: transparent;
 			span[role=img]>svg {
-				height: 24px;
-				width: 24px;
+				height: 16px;
 				color: var(--ion-button-sidebar-text);
 			}
 			&:hover {


### PR DESCRIPTION
## Summary

- Removes the `.vs__open-indicator-button svg` size override that was added to compensate for Font Awesome chevron icons rendering smaller than MDI equivalents
- This workaround is no longer needed since MDI icons are now used
